### PR TITLE
Remove base controller dependency

### DIFF
--- a/src/LaravelWindowSizeController.php
+++ b/src/LaravelWindowSizeController.php
@@ -3,9 +3,8 @@
 namespace Tanthammar\LaravelWindowSize;
 
 use Illuminate\Http\Request;
-use App\Http\Controllers\Controller;
 
-class LaravelWindowSizeController extends Controller
+class LaravelWindowSizeController
 {
     /**
      * Handle the incoming request.


### PR DESCRIPTION
Currently the LaravelWindowsSizeController extends the Laravel base controller. This does not work in projects where the base controller is not at `App\Http\Controllers\Controller`.
The good news is that the base controller's function are not utilized at all, so we can just remove it.

Has been tested and works!